### PR TITLE
Add auto-mode-alist with autoload cookie

### DIFF
--- a/unison-mode.el
+++ b/unison-mode.el
@@ -134,6 +134,8 @@
   (interactive)
   (shell-command unison-command))
 
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.prf$" . unison-mode))
 
 (provide 'unison-mode)
 ;;; unison-mode.el ends here


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/). This commit ensures that users who have installed `union-mode` from [MELPA](http://melpa.milkbox.net/)  will be able to automatically turn on `union-mode` when visiting a `prf` file without explicitly requiring the library first. For information about this fix [Packaging-Basics](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging-Basics.html).
